### PR TITLE
クラウド実行を高速化

### DIFF
--- a/MarathonRunner.CloudCompiler.Rust/rust/Cargo.toml
+++ b/MarathonRunner.CloudCompiler.Rust/rust/Cargo.toml
@@ -10,7 +10,7 @@ name = "main"
 path = "src/bin/main.rs"
 
 [profile.release]
-lto = true # コンパイル時間が著しく長くなってしまう場合は無し
+#lto = true # コンパイル時間が著しく長くなってしまう場合は無し
 
 [dependencies]
 # 202301から:

--- a/MarathonRunner.Console/Commands.cs
+++ b/MarathonRunner.Console/Commands.cs
@@ -127,4 +127,11 @@ public class Commands : ConsoleAppBase
     {
         await _cloudRunner.RunAsync(comment, Context.CancellationToken);
     }
+
+    [Command("compile-run-cloud", "Rustのコンパイルを実行したのち、クラウド上でテストケースを実行します。")]
+    public async Task CompileRunCloudAsync([Option("c", "テストケースのコメント")] string comment = "")
+    {
+        await _rustCompileDispatcher.CompileAsync(Context.CancellationToken);
+        await _cloudRunner.RunAsync(comment, Context.CancellationToken);
+    }
 }

--- a/MarathonRunner.Infrastructures.GoogleCloud/Compilers/RustCompileDispatcher.cs
+++ b/MarathonRunner.Infrastructures.GoogleCloud/Compilers/RustCompileDispatcher.cs
@@ -26,7 +26,7 @@ public class RustCompileDispatcher : ICompileDispatcher
         _exeName = compileOption.Value.ExeName;
         _compileFiles = compileOption.Value.Files;
         _httpClient = httpClient;
-        _tokenService = new IdTokenService();
+        _tokenService = IdTokenService.Instance;
     }
 
     public async Task CompileAsync(CancellationToken ct = default)

--- a/MarathonRunner.Infrastructures.GoogleCloud/GoogleCloudDispatcher.cs
+++ b/MarathonRunner.Infrastructures.GoogleCloud/GoogleCloudDispatcher.cs
@@ -22,7 +22,7 @@ public class GoogleCloudDispatcher : Dispatcher
         ArgumentNullException.ThrowIfNull(endPoint);
         _endPoint = endPoint;
         _httpClient = httpClient;
-        _tokenService = new IdTokenService();
+        _tokenService = IdTokenService.Instance;
     }
 
     protected override async Task<TestCaseResult> DispatchAsyncInner(SingleCaseExecutorArgs args, CancellationToken ct = default)

--- a/MarathonRunner.Infrastructures.GoogleCloud/IdTokenService.cs
+++ b/MarathonRunner.Infrastructures.GoogleCloud/IdTokenService.cs
@@ -10,6 +10,10 @@ internal class IdTokenService
     private readonly object _lockObject = new();
     private static readonly TimeSpan TokenExpiration = TimeSpan.FromMinutes(30);
 
+    private static readonly IdTokenService _instance = new();
+
+    public static IdTokenService Instance => _instance;
+
     public Task<string> GetIdTokenAsync(CancellationToken ct = default)
     {
         lock (_lockObject)


### PR DESCRIPTION
以下の高速化を行った。

- コンパイルとテストケース実行を1コマンドで行うようにした
  - `IdTokenService` をシングルトンにすることでトークン取得を1回で済ませるようにした
- RustのコンパイルオプションからLTOを削除した
- ファイルコピーを高速化した